### PR TITLE
A fix for issue #4

### DIFF
--- a/client/posting.js
+++ b/client/posting.js
@@ -73,7 +73,7 @@ function insert_pbs() {
 		return;
 	if (THREAD ? $('aside').length : $ceiling.next().is('aside'))
 		return;
-	make_reply_box().appendTo('section');
+	make_reply_box().insertBefore('div.clearfix');
 	if (!nashi.upload && (BUMP || PAGE == 0))
 		$ceiling.after('<aside class="act"><a>New thread</a></aside>');
 }

--- a/server/server.js
+++ b/server/server.js
@@ -167,7 +167,7 @@ function write_thread_html(reader, req, response, opts) {
 		response.write(oneeSama.mono(post));
 	});
 	reader.on('endthread', function () {
-		response.write('</section><hr>\n');
+		response.write('<div class="clearfix"></div></section><hr>\n');
 	});
 }
 

--- a/www/css/base-v32.css
+++ b/www/css/base-v32.css
@@ -1,3 +1,6 @@
+div.clearfix {
+  clear:both;
+}
 a {
 	border: none;
 	text-decoration: underline;
@@ -81,10 +84,15 @@ h3 {
 }
 header {
 	background: url('ui/box.png') left 3px no-repeat;
-	margin-left: -3px;
-	padding-left: 14px;
+	margin-left: -14px;
 	position: relative;
 }
+
+article header {
+  margin-left: -3px;
+	padding-left: 14px;
+}
+
 header nav a {
 	text-decoration: none;
 }
@@ -125,8 +133,11 @@ small {
 	display: block;
 	padding-top: 0.5em;
 }
+span.control ul {
+  z-index:10;
+}
+
 ul {
-	background: url('ui/box.png') 10px 10px no-repeat;
 	border-bottom: none;
 	position: absolute;
 	margin: 0;
@@ -177,6 +188,10 @@ figure {
 	display: block;
 	position: relative;
 }
+section > figure a {
+  position:relative;
+  z-index:5;
+}
 .hat, .expanded .hat {
 	background: url('ui/hat.png') no-repeat;
 	position: absolute;
@@ -223,11 +238,16 @@ article .hat {
 	position: absolute;
 }
 .scroll-lock {
-	margin-left: -10px;
+  background-color:rgba(0, 0, 0, 0.05);
+  padding:3px 0 0 5px;
 }
 .scroll-lock header {
 	background-image: url('ui/lock.png');
 	background-position: 0 0;
+}
+
+section.scroll-lock > header {
+  margin-left:-19px;
 }
 
 .multi-select article {


### PR DESCRIPTION
Hi! I've attempted to fix #4 by using `z-index` to place the expanded image on top of the `header` tag, thus making the expanded image's link "clickable" again.

In order to do this, I've moved the lock/unlock button a little bit to the left and added a different style to differentiate locked threads (instead of differentiating them using `margin-left`, like previously).

I noticed that the css files have a suffix with a version. Should I increase `base-v32.css` number to 33?

In case you approve the new locked thread style, I can apply it to the other themes and add them to this pull request.
