### PR TITLE
A new fix for #4

### DIFF
--- a/client/posting.js
+++ b/client/posting.js
@@ -73,7 +73,7 @@ function insert_pbs() {
 		return;
 	if (THREAD ? $('aside').length : $ceiling.next().is('aside'))
 		return;
-	make_reply_box().insertBefore('div.clearfix');
+  make_reply_box().appendTo('section');
 	if (!nashi.upload && (BUMP || PAGE == 0))
 		$ceiling.after('<aside class="act"><a>New thread</a></aside>');
 }

--- a/server/server.js
+++ b/server/server.js
@@ -167,7 +167,7 @@ function write_thread_html(reader, req, response, opts) {
 		response.write(oneeSama.mono(post));
 	});
 	reader.on('endthread', function () {
-		response.write('<div class="clearfix"></div></section><hr>\n');
+		response.write('</section><hr>\n');
 	});
 }
 

--- a/www/css/base-v34.css
+++ b/www/css/base-v34.css
@@ -1,6 +1,3 @@
-div.clearfix {
-  clear:both;
-}
 a {
 	border: none;
 	text-decoration: underline;


### PR DESCRIPTION
I've finally managed to redo the fix for #4, now with the changes you've required. The changes have been broken down to separate commits. I have not included the .scroll-lock styling this time.

About the `div.clearfix`, it is a common technique to deal with problems caused by using float elements. Here's a good description that [I found](http://www.webtoolkit.info/css-clearfix.html):

> The problem happens when a floated element is within a container box, that element does not automatically force the container’s height adjust to the floated element. When an element is floated, its parent no longer contains it because the float is removed from the flow.

So by placing the `<div style="clear:both;"></div>` at the end of the container, we force it to contain all  of its children, regardless of the `float` property.
