### PR TITLE
Top link at page bottom

### DIFF
--- a/server/render.js
+++ b/server/render.js
@@ -172,7 +172,7 @@ exports.make_pagination_html = function (info) {
 };
 
 var returnHTML = common.action_link_html('.', 'Return').replace(
-		'span', 'span id="bottom"');
+		'span', 'span id="bottom"').replace('</span>', '] [<a href="#">Top</a></span>');
 
 exports.write_page_end = function (out, ident, returnLink) {
 	if (returnLink)


### PR DESCRIPTION
Primarily for mobile browsing convenience, as not all options have a quick way to scroll to the top. Eliminates a lot of finger flicking. 
