### PR TITLE
Lossy PNG thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dependencies:
 * node.js + npm
 * redis
 * ffmpeg 2.2+ if supporting WebM
+* pngquant 2.2.0+ if PNG thumbnails enabled
 
 Optional npm deps for various features:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dependencies:
 * node.js + npm
 * redis
 * ffmpeg 2.2+ if supporting WebM
-* pngquant 2.2.0+ if PNG thumbnails enabled
+* pngquant  2.3.1+ for PNG thumbnails
 
 Optional npm deps for various features:
 

--- a/imager/config.js.example
+++ b/imager/config.js.example
@@ -24,9 +24,9 @@ module.exports = {
 	THUMB_DIMENSIONS: [250, 250],
 	EXTRA_MID_THUMBNAILS: true,
 	// PNG thumbnails for PNG images. This enables thumbnail transparency.
-	// Warning: significantly increases page size for large threads.
 	PNG_THUMBS: false,
-	PNG_THUMB_QUALITY: 105,
+	// pngquant quality setting
+	PNG_THUMB_QUALITY: 10,
 	WEBM: false,
 	WEBM_AUDIO: false,
 	// uncomment this to have all audio WebMs overlaid with

--- a/imager/config.js.example
+++ b/imager/config.js.example
@@ -25,8 +25,8 @@ module.exports = {
 	EXTRA_MID_THUMBNAILS: true,
 	// PNG thumbnails for PNG images. This enables thumbnail transparency.
 	PNG_THUMBS: false,
-	// pngquant quality setting
-	PNG_THUMB_QUALITY: 10,
+	// pngquant quality setting. Consult the manpages for more details
+	PNG_THUMB_QUALITY: '0-10',
 	WEBM: false,
 	WEBM_AUDIO: false,
 	// uncomment this to have all audio WebMs overlaid with

--- a/imager/daemon.js
+++ b/imager/daemon.js
@@ -473,6 +473,11 @@ if (config.WEBM) {
 	which('ffmpeg', function (bin) { ffmpegBin = bin; });
 }
 
+var pngquantBin;
+if (config.PNG_THUMBS){
+	which('pngquant', function (bin) { pngquantBin = bin; });
+}
+
 function identify(taggedName, callback) {
 	var m = taggedName.match(/^(\w{3,4}):/);
 	var args = ['-format', '%Wx%H', taggedName + '[0]'];
@@ -620,12 +625,26 @@ function resize_image(o, comp, callback) {
 	else if (o.bg)
 		args.push('-layers', 'mosaic', '+matte');
 	// disregard metadata, acquire artifacts
-	args.push('-strip', '-quality', o.quality);
+	args.push('-strip');
+	if (o.bg || comp)
+		args.push('-quality', o.quality);
 	args.push(dest);
 	convert(args, o.src, function (err) {
 		if (err) {
 			winston.warn(err);
 			callback(Muggle("Resizing error.", err));
+		}
+		// Lossify PNG thumbnail
+		else if(!o.bg){
+			var pqDest = dest.slice(4);
+			child_process.execFile(pngquantBin, ['-f', '-o', pqDest, '--quality', o.quality, pqDest],
+				function(err, stdout, stderr){
+					if (err) {
+						winston.warn(stderr);
+						callback(Muggle("Resizing error.", stderr));
+					} else
+						callback(null, dest);
+			});
 		}
 		else
 			callback(null, dest);

--- a/imager/daemon.js
+++ b/imager/daemon.js
@@ -638,10 +638,10 @@ function resize_image(o, comp, callback) {
 		else if(!o.bg){
 			var pqDest = dest.slice(4);
 			child_process.execFile(pngquantBin, ['-f', '-o', pqDest, '--quality', o.quality, pqDest],
-				function(err, stdout, stderr){
+				function(err){
 					if (err) {
-						winston.warn(stderr);
-						callback(Muggle("Resizing error.", stderr));
+						winston.warn(err);
+						callback(Muggle("Pngquant thumbnailing error.", err));
 					} else
 						callback(null, dest);
 			});


### PR DESCRIPTION
Uses pngquant for lossy compression. Reduces PNG thumbnail size 8-10 times on default settings.
Addresses https://github.com/lalcmellkmal/doushio/issues/71 & https://github.com/bakape/doushio/issues/67