### PR TITLE
Pass THEME_CSS_VERSION to client

### DIFF
--- a/client/options.js
+++ b/client/options.js
@@ -127,7 +127,6 @@ var themes = [
 	'tea',
 	'higan',
 ];
-var globalVersion = 8;
 
 function option_theme(theme) {
 	if (theme) {

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -7,6 +7,7 @@
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0">
 $META	<!--[if lt IE 9]><script src="{{MEDIA_URL}}js/ie.js"></script><![endif]-->
 	<script src="{{MEDIA_URL}}js/setup.js?v=5"></script>
+	<script>var globalVersion = {{THEME_CSS_VERSION}};</script>
 </head>
 <a id="feedback" href="mailto:{{EMAIL}}">Feedback</a>
 $NAV


### PR DESCRIPTION
I noticed that the CSS version isn't bumped up, if the client has a theme setting, because `client/options.js` overrides it. So here's a very lengthy solution~
