### PR TITLE
Open mailto links in a new tab

### DIFF
--- a/client/posting.js
+++ b/client/posting.js
@@ -305,7 +305,7 @@ propagate_ident: function () {
 		email = '';
 	var tag = meta.children('a:first');
 	if (email)
-		tag.attr('href', 'mailto:' + email).attr('class', 'email');
+		tag.attr({'href': 'mailto:' + email, 'target': '_blank', 'class': 'email', });
 	else
 		tag.removeAttr('href').attr('class', 'nope');
 },

--- a/common.js
+++ b/common.js
@@ -679,7 +679,7 @@ OS.atama = function (data) {
 	header.push(safe('</b>'));
 	if (data.email) {
 		header.unshift(safe('<a class="email" href="mailto:'
-				+ encodeURI(data.email) + '">'));
+			+ encodeURI(data.email) + '" target="_blank">'));
 		header.push(safe('</a>'));
 	}
 	header.push(safe(' <time datetime="' + datetime(data.time) +

--- a/tmpl/index.html
+++ b/tmpl/index.html
@@ -8,7 +8,7 @@
 $META	<!--[if lt IE 9]><script src="{{MEDIA_URL}}js/ie.js"></script><![endif]-->
 	<script src="{{MEDIA_URL}}js/setup.js?v=5"></script>
 </head>
-<a id="feedback" href="mailto:{{EMAIL}}">Feedback</a>
+<a id="feedback" href="mailto:{{EMAIL}}" target="_blank">Feedback</a>
 $NAV
 <h1>$TITLE</h1>
 <span id="sync">Not synched.</span>


### PR DESCRIPTION
Prevents webmail clients from replacing tab content. No effect on traditional email clients.

Today is a day off small PRs. 
